### PR TITLE
Bugfix: mkdir(): No such file or directory

### DIFF
--- a/app/code/community/Technooze/Timage/Helper/Data.php
+++ b/app/code/community/Technooze/Timage/Helper/Data.php
@@ -300,15 +300,16 @@ class Technooze_Timage_Helper_Data extends Mage_Core_Helper_Abstract
         $cache = BP . DS . 'media' . DS . 'catalog' . DS . 'cache' . DS;
         $cropCache = $cache . 'cropped' . DS;
 
-        if(!is_dir($cropCache))
-        {
-            mkdir($cropCache);
-        }
-
         if(!is_dir($cache))
         {
             mkdir($cache);
         }
+
+        if(!is_dir($cropCache))
+        {
+            mkdir($cropCache);
+        }
+        
         $this->cacheDir = $cache;
         $this->croppedCacheDir = $cropCache;
     }


### PR DESCRIPTION
Warning: mkdir(): No such file or directory in
app/code/community/Technooze/Timage/Helper/Data.php on line 305

Technooze_Timage_Helper_Data->cacheDir() create cacheDir first an then
cropCache
