### PR TITLE
Fixed infinite recursion when using image placeholder

### DIFF
--- a/app/code/community/Technooze/Timage/Helper/Data.php
+++ b/app/code/community/Technooze/Timage/Helper/Data.php
@@ -62,7 +62,7 @@ class Technooze_Timage_Helper_Data extends Mage_Core_Helper_Abstract
 
         if(empty($this->placeHolder))
         {
-            $this->placeHolder = Mage::getDesign()->getSkinUrl() . 'images/catalog/product/placeholder/image.jpg';
+            $this->placeHolder = Mage::getDesign()->getSkinUrl('images/catalog/product/placeholder/image.jpg');
         }
 
         if($img)


### PR DESCRIPTION
With this fix, the fallback placeholder in base skin will be used when there are no placeholder images in custom theme.
