### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ If you are working on localhost using IP, you need to add `->setRemoveHttp(false
 	?>" alt="alt text"/>
 ```
 
-###visit: dltr.org for more [Magento Tips, Tricks and Free Extensions](http://dltr.org/).
+### visit: dltr.org for more [Magento Tips, Tricks and Free Extensions](http://dltr.org/).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
